### PR TITLE
Add difficulty adjustment simulator

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,7 @@
-# Note that the following values of blocks 154998 and 15499 were extracted directly from a break-point while running
-# Electrum. They can be used to test the read_headers() function when calling Electrum routines.
+from xrc_simulations.simulations import PowSimulator
 
+
+# Blocks 154998 and 15499 were extracted directly from a break-point while running the Electrum wallet.
 ELECTRUM_154998 = {
     "version": 536870912,
     "previousBlockHash": "a872f8d169e7f48d04f31f174024501d0ec2898ea16e07ae2091b2526be8aa1c",
@@ -21,9 +22,7 @@ ELECTRUM_154999 = {
     "blockIndex": 154999,
 }
 
-# The following data was downloaded directly from the blockCore API. It can be used to test routines that
-# handle blockCore data.
-
+# BLOCKCORE_SAMPLE data was downloaded directly from the blockCore API.
 BLOCKCORE_SAMPLE = [
     {
         "blockHash": "a71caca3f80bbedbaf588745244f8781e97fcea109fabbc63b52943dc468ab57",
@@ -60,3 +59,18 @@ BLOCKCORE_SAMPLE = [
         "version": 536870912,
     },
 ]
+
+
+class FixtureSimulator(PowSimulator):
+    def __init__(self, network, miners, time_deltas):
+        self._time_deltas = time_deltas
+        super().__init__(network, miners)
+
+    def get_block_time(self, target, hashrate):
+        """
+        Override get_block_time routine, to return known block-times for tests
+        """
+        assert len(self._time_deltas) > 0, "No block-times available"
+        time = self._time_deltas[0]
+        self._time_deltas = self._time_deltas[1:]
+        return time

--- a/tests/test_digishield.py
+++ b/tests/test_digishield.py
@@ -1,34 +1,35 @@
 from tests.fixtures import ELECTRUM_154999, ELECTRUM_154998
+from xrc_utils import digishield
 from xrc_utils.digishield import (
-    read_header,
     target_to_bits,
     get_targetDigishield,
     bits_to_target,
 )
 from xrc_utils.electrum import dump_blockchain_headers_file_to_df
+from xrc_utils.headers import BLOCKCHAIN_HEADERS_PATH
 
 
-def test_read_header():
+def test_digishield_read_header():
     # Get raw data directly from the Electrum blockchain_headers file
     df = dump_blockchain_headers_file_to_df(
-        read_header.DATA_PATH, bits_format="electrum"
+        BLOCKCHAIN_HEADERS_PATH, bits_format="electrum"
     )
 
     for h in [149585, 154990, 151877]:
-        header = read_header(h)
+        header = digishield.read_header(h)
         for key in header:
             assert (
                 header[key] == df.loc[h].to_dict()[key]
-            ), f"Mismatch between read_header and parsed df at height = {h}"
+            ), f"Mismatch between digishield.read_header and parsed df at height = {h}"
 
 
-def test_read_header_against_extracted_data():
+def test_digishield_against_extracted_data():
     # Compare the decoding against data extracted from the Electrum wallet internals using a breakpoint...
-    block_154999 = read_header(154999)
+    block_154999 = digishield.read_header(154999)
     for key in ELECTRUM_154999:
         assert ELECTRUM_154999[key] == block_154999[key]
 
-    block_154998 = read_header(154998)
+    block_154998 = digishield.read_header(154998)
     for key in ELECTRUM_154998:
         assert ELECTRUM_154998[key] == block_154998[key]
 
@@ -37,6 +38,10 @@ def test_get_targetDigishield():
     # Make sure that get_targetDigishield returns the expected value for the next target, which is stored in the
     # blockchain data.
     for h in [154999, 151515, 152737]:
-        assert target_to_bits(get_targetDigishield(h)) == read_header(h)["bits"]
+        assert (
+            target_to_bits(get_targetDigishield(h)) == digishield.read_header(h)["bits"]
+        )
 
-        assert get_targetDigishield(h) == bits_to_target(read_header(h)["bits"])
+        assert get_targetDigishield(h) == bits_to_target(
+            digishield.read_header(h)["bits"]
+        )

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,0 +1,133 @@
+from copy import copy
+
+import numpy as np
+from xrc_simulations.miners import SimpleMiner
+from xrc_simulations.network import XRCDigishieldNetwork
+from xrc_simulations.simulations import XRCBlock, NetworkConfig, GHZ, PowSimulator
+from tests.fixtures import ELECTRUM_154999, FixtureSimulator
+from xrc_simulations.utils import convert_list_to_blockchain
+from xrc_utils import digishield
+from xrc_utils.blockcore import target_to_difficulty
+from xrc_utils.digishield import (
+    bits_to_target,
+    get_targetDigishield,
+    target_to_bits,
+)
+
+
+def test_xrc_block_to_json():
+
+    next_block = XRCBlock(
+        version=536870912,
+        previous_block_hash="536fd637e87dfa548857b81c46f9078344949f2b8d858b305a5c1f6b4ce06640",
+        merkleroot="4f72d77f443edb77eadf67ad3cbdad4d0115a31f481968af04772629ee570b73",
+        block_time=1664212597,
+        bits=453151324,
+        nonce=3374795661,
+        block_index=154999,
+    )
+
+    next_block_json = next_block.to_json()
+
+    assert next_block_json == ELECTRUM_154999
+
+
+def test_network_config():
+    config = NetworkConfig(block_time=1664212597, block_index=154999, bits=453151324)
+
+    assert config.target == bits_to_target(453151324)
+
+    assert config.difficulty == target_to_difficulty(bits_to_target(453151324))
+
+
+def test_network_prediction():
+    """
+    When a synthetic blockchain is initiated from a real data, check that the first target prediction
+    agrees with the corresponding target in the real data.
+    """
+    raw_data = [digishield.read_header(idx) for idx in range(150000, 150500)]
+
+    n = 491
+    blockchain = convert_list_to_blockchain(raw_data[0 : n + 1])
+
+    data = raw_data[n]  # Last data point in the blockchain
+    next_data = raw_data[n + 1]
+    next_idx = next_data["blockIndex"]
+
+    config = NetworkConfig(
+        block_index=data["blockIndex"],
+        block_time=data["blockTime"],
+        bits=next_data["bits"],
+    )
+
+    network = XRCDigishieldNetwork(blockchain=copy(blockchain), config=config)
+
+    miners = [
+        SimpleMiner(blockchain=copy(blockchain), hash_rate=100 * GHZ),
+    ]
+
+    simulator = PowSimulator(network=network, miners=miners)
+
+    simulator.run(1)
+
+    fake_data = network.read_header(next_idx)
+
+    real_data = digishield.read_header(next_idx)
+
+    # The next target from the simulator should be the target from the real data
+    assert fake_data["bits"] == target_to_bits(get_targetDigishield(next_idx))
+
+    # The target and block index should agree one-step ahead
+    assert real_data["bits"] == fake_data["bits"]
+    assert real_data["blockIndex"] == fake_data["blockIndex"]
+
+    # The merkleroot of the fake data equals 'synthetic'
+    assert real_data["merkleroot"] != "synthetic"
+    assert fake_data["merkleroot"] == "synthetic"
+
+
+def test_with_known_block_times():
+    """
+    Check that we recover the correct targets when feeding known block times.
+    """
+    raw_data = [digishield.read_header(idx) for idx in range(150000, 151000)]
+
+    n = 491  # !- must select n < 1000
+    blockchain = convert_list_to_blockchain(raw_data[0 : n + 1])
+
+    data = raw_data[n]  # Last data point in the blockchain
+    next_data = raw_data[n + 1]
+
+    config = NetworkConfig(
+        block_index=data["blockIndex"],
+        block_time=data["blockTime"],
+        bits=next_data["bits"],
+    )
+
+    # Calculate the time-since-last-block for the blocks walking forward from the end of the real data.
+    block_times = []
+    for data in raw_data[n:1000]:
+        block_times.append(data["blockTime"])
+
+    block_times = np.array(block_times)
+    time_deltas = block_times[1:] - block_times[:-1]
+
+    # Instantiate a simulation, using the known time-deltas
+    network = XRCDigishieldNetwork(blockchain=copy(blockchain), config=config)
+
+    miners = [
+        SimpleMiner(blockchain=copy(blockchain), hash_rate=100 * GHZ),
+    ]
+
+    simulator = FixtureSimulator(
+        network=network, miners=miners, time_deltas=time_deltas
+    )
+
+    simulator.run(1000 - n - 1)
+
+    for idx in network.blockchain:
+        assert (
+            network.blockchain[idx]["blockTime"]
+            == digishield.read_header(idx)["blockTime"]
+        )
+        assert network.blockchain[idx]["bits"] == digishield.read_header(idx)["bits"]

--- a/xrc_experiments/experiment_1.py
+++ b/xrc_experiments/experiment_1.py
@@ -1,0 +1,98 @@
+from datetime import datetime
+import pandas as pd
+
+from xrc_simulations.utils import convert_list_to_blockchain
+from xrc_simulations.simulations import NetworkConfig, GHZ, THZ
+from xrc_simulations.simulations import PowSimulator
+from xrc_simulations.network import XRCDigishieldNetwork
+from xrc_simulations.miners import SimpleMiner, AttackMiner
+from xrc_utils import digishield
+from xrc_utils.blockcore import target_to_difficulty, get_blockcore_df
+from xrc_utils.digishield import bits_to_target
+import matplotlib.pyplot as plt
+
+
+def parse_df(df):
+
+    # Convert bits to target
+    df["target"] = df["bits"].apply(lambda x: bits_to_target(x))
+
+    # Add time-since-last block in minutes
+    df["timeDeltaMinutes"] = (df["blockTime"] - df["blockTime"].shift(1)) * 1.0 / 60
+
+    # Convert ordinal time-of-day to timestamp
+    df["time"] = df["blockTime"].apply(lambda x: datetime.fromtimestamp(int(x)))
+
+    # Calculate percentage change in target
+    df["targetChange"] = df["target"] * 1.0 / df["target"].shift(1)
+
+    # Add difficulty (as shown in blockCore -- could be too low by a factor of 4096)
+    df["difficulty"] = df["target"].apply(lambda x: target_to_difficulty(x))
+
+    df["difficultyPercentChange"] = (
+        df["difficulty"] * 1.0 / df["difficulty"].shift(1) - 1
+    )
+
+    return df
+
+
+def create_plot(df_simulated, df_real):
+    fig, (ax1, ax2) = plt.subplots(2, 1)
+
+    df_simulated[["time", "difficulty"]].set_index("time").plot(ax=ax1, marker="o")
+
+    ax1.set_xlim([df_real["time"].values[0], df_real["time"].values[-1]])
+
+    df_real[["time", "difficulty"]].set_index("time").plot(ax=ax2, marker="o")
+
+    ax2.set_xlim([df_real["time"].values[0], df_real["time"].values[-1]])
+
+    plt.gcf().set_size_inches(10, 5)
+
+    plt.tight_layout()
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    n = 150
+
+    raw_data = [digishield.read_header(idx) for idx in range(150000, 151000)]
+
+    blockchain = convert_list_to_blockchain(raw_data[0 : n + 1])
+
+    data = raw_data[n]  # Current data point
+    next_data = raw_data[n + 1]
+
+    config = NetworkConfig(
+        block_index=data["blockIndex"],
+        block_time=data["blockTime"],
+        bits=next_data["bits"],
+    )
+
+    network = XRCDigishieldNetwork(blockchain=blockchain, config=config)
+
+    miners = [
+        SimpleMiner(blockchain=blockchain, hash_rate=300 * GHZ),
+        AttackMiner(blockchain=blockchain, hash_rate=70 * THZ, on=False),
+    ]
+
+    simulator = PowSimulator(network=network, miners=miners)
+
+    simulator.run(850)
+
+    # Extract the simulated blockchain data, and parse it into a useful dataframe
+    df_simulated = pd.DataFrame(network.blockchain).T
+
+    df_simulated = parse_df(df_simulated)
+
+    # Download data from blockCore
+    df_real = get_blockcore_df(nmb_blocks=1000, offset=150000)
+
+    df_real["bits"] = df_real["bits"].apply(
+        lambda x: int(x, 16)
+    )  # Convert to Electrum bits format
+
+    df_real = parse_df(df_real)
+
+    create_plot(df_simulated, df_real)

--- a/xrc_simulations/miners.py
+++ b/xrc_simulations/miners.py
@@ -1,0 +1,27 @@
+from xrc_simulations.simulations import MockMinerBase, NetworkConfig, THZ, GHZ
+
+
+class SimpleMiner(MockMinerBase):
+    def set_hash_rate(self, *args):
+        """
+        Hash-rate is set by the constructor. So pass.
+        """
+        pass
+
+
+class AttackMiner(MockMinerBase):
+    def __init__(self, blockchain: dict, hash_rate: int, on: bool = False):
+        self._hp = hash_rate
+        if on:
+            self._hash_rate = hash_rate
+        else:
+            self._hash_rate = 0
+
+        super().__init__(blockchain, hash_rate)
+
+    def set_hash_rate(self, config: NetworkConfig, *args):
+        if config.difficulty < 50000 * 2**12:
+            if self._hash_rate == 0:
+                self._hash_rate = self._hp
+        elif config.difficulty > 750000 * 2**12:
+            self._hash_rate = 0

--- a/xrc_simulations/network.py
+++ b/xrc_simulations/network.py
@@ -1,0 +1,100 @@
+from xrc_simulations.simulations import MockNetworkBase
+from xrc_utils.digishield import (
+    DIGISHIELDX11_BLOCK_HEIGHT,
+    MissingHeader,
+    bits_to_target,
+    target_to_bits,
+    MAX_TARGET,
+)
+
+
+class XRCDigishieldNetwork(MockNetworkBase):
+    def get_averageTimepast(self, height: int) -> int:
+        medianTimespan = 11
+        median = list()
+
+        for i in range(medianTimespan):
+            chainedHeader = self.read_header(height - i)
+            if chainedHeader is None:
+                break
+            else:
+                median.append(chainedHeader.get("blockTime"))
+
+        median.sort()
+
+        firstTimespan = median[0]
+        lastTimespan = median[-1]
+        differenceTimespan = lastTimespan - firstTimespan
+        timespan = int(differenceTimespan / 2)
+        averageDateTime = firstTimespan + timespan
+
+        return averageDateTime
+
+    def get_medianTimepast(self, height: int) -> int:
+        medianTimespan = 11
+        median = medianTimespan * [0]
+        begin = medianTimespan
+        end = medianTimespan
+
+        for i in range(medianTimespan):
+            chainedHeader = self.read_header(height - i)
+            if chainedHeader is None:
+                break
+            else:
+                begin = begin - 1
+                median[i] = chainedHeader.get(
+                    "blockTime"
+                )  # Note that 'timestamp' in Electrum is 'blockTime' in Blockcore
+
+        median.sort()
+
+        return median[int(begin + ((end - begin) / 2))]
+
+    def get_target(self, height):
+        nAveragingInterval = 10 * 5  # block
+        multiAlgoTargetSpacingV4 = 10 * 60  # seconds
+        nAveragingTargetTimespanV4 = nAveragingInterval * multiAlgoTargetSpacingV4
+        nMaxAdjustDownV4 = 16
+        nMaxAdjustUpV4 = 8
+        nMinActualTimespanV4 = nAveragingTargetTimespanV4 * (100 - nMaxAdjustUpV4) / 100
+        nMaxActualTimespanV4 = (
+            nAveragingTargetTimespanV4 * (100 + nMaxAdjustDownV4) / 100
+        )
+        # medianTimespan = 11
+
+        if (height - DIGISHIELDX11_BLOCK_HEIGHT) <= (nAveragingInterval + 11):
+            return int(
+                0x000000000001A61A000000000000000000000000000000000000000000000000
+            )
+
+        last = self.read_header(height - 1)
+        first = self.read_header(height - nAveragingInterval)
+        if not first or not last:
+            raise MissingHeader()
+
+        # Limit adjustment step
+        # Use medians to prevent time-warp attacks
+        last_averagetimestamp = self.get_averageTimepast(
+            last.get("blockIndex")
+        )  # Note that blockIndex in blockcore -> block_height in electrum
+        first_averagetimestamp = self.get_averageTimepast(first.get("blockIndex"))
+        nActualTimespan = last_averagetimestamp - first_averagetimestamp
+        nActualTimespan = (
+            nAveragingTargetTimespanV4
+            + (nActualTimespan - nAveragingTargetTimespanV4) / 4
+        )
+
+        if nActualTimespan < nMinActualTimespanV4:
+            nActualTimespan = nMinActualTimespanV4
+        if nActualTimespan > nMaxActualTimespanV4:
+            nActualTimespan = nMaxActualTimespanV4
+
+        bits = last.get("bits")
+        target = bits_to_target(bits)
+        new_target = target * int(nActualTimespan)
+        new_target = new_target / nAveragingTargetTimespanV4
+        new_targetBits = target_to_bits(int(new_target))
+        bitsToTarget = bits_to_target(new_targetBits)
+        bitsToTarget = min(MAX_TARGET, bitsToTarget)
+        assert bits_to_target(target_to_bits(bitsToTarget)) == bitsToTarget
+        return target_to_bits(bitsToTarget)

--- a/xrc_simulations/simulations.py
+++ b/xrc_simulations/simulations.py
@@ -1,0 +1,179 @@
+from dataclasses import dataclass
+from typing import List, Type
+import numpy as np
+from numpy.random import choice
+from xrc_utils.blockcore import target_to_difficulty
+from xrc_utils.digishield import bits_to_target, MAX_TARGET
+from copy import copy
+
+SEED = 1234
+
+GHZ = 10**9
+THZ = 10**12
+
+
+@dataclass
+class XRCBlock:
+    version: int
+    previous_block_hash: str
+    merkleroot: str
+    block_time: int
+    bits: int
+    nonce: int
+    block_index: int
+
+    def to_json(self) -> dict:
+        return {
+            "version": self.version,
+            "previousBlockHash": self.previous_block_hash,
+            "merkleroot": self.merkleroot,
+            "blockTime": self.block_time,
+            "bits": self.bits,
+            "nonce": self.nonce,
+            "blockIndex": self.block_index,
+        }
+
+
+@dataclass
+class NetworkConfig:
+    block_time: int
+    block_index: int
+    bits: int
+
+    @property
+    def difficulty(self) -> float:
+        return target_to_difficulty(self.target)
+
+    @property
+    def target(self) -> int:
+        return bits_to_target(self.bits)
+
+
+class MockMinerBase:
+    """
+    Base class for miner-xrc_simulations
+    """
+
+    def __init__(self, blockchain: dict, hash_rate: int):
+        self.blockchain = copy(
+            blockchain
+        )  # Note: The blockchain should be a copy in each miner...
+        self._hash_rate = hash_rate
+
+    def set_hash_rate(self, *args):
+        raise NotImplementedError
+
+    @property
+    def hash_rate(self):
+        return self._hash_rate
+
+    def create_block(self, config: NetworkConfig, time_delta: int, nonce: int):
+        synthetic_hash = f"synthetic_{config.block_index}"  # TODO: This is a hack. Replace with the correct hash.
+        next_block = XRCBlock(
+            version=0,
+            previous_block_hash=synthetic_hash,
+            merkleroot="synthetic",
+            block_time=config.block_time + time_delta,
+            bits=config.bits,
+            nonce=nonce,
+            block_index=config.block_index + 1,
+        )
+        return next_block
+
+    def update(self, config: NetworkConfig, next_block: XRCBlock):
+        self.blockchain[next_block.block_index] = next_block.to_json()
+        self.set_hash_rate(config)
+
+
+class MockNetworkBase:
+    """
+    Base class to simulate various difficulty adjustments schemes such as DigiShield V0. Once the network difficulty is
+    set, time-to-next block can be treated as a Gamma random variable that depends on the network-wide hash-rate and
+    the difficulty. Inherit from this class and implement the get_target routine, which should contain the difficulty
+    adjustment logic.
+    """
+
+    def __init__(self, blockchain: dict, config: NetworkConfig):
+        self.blockchain = copy(blockchain)  # The blockchain should be a copy
+        self.config = config
+        self.logging_list = []
+
+    @property
+    def difficulty(self):
+        return self.config.difficulty
+
+    @property
+    def target(self):
+        return self.config.target
+
+    def read_header(self, idx):
+        header = self.blockchain.get(idx)
+        assert (header is not None) & (
+            header["blockIndex"] == idx
+        ), f"Block index {idx} is not valid"
+        return header
+
+    def get_target(self, *args):
+        raise NotImplementedError
+
+    def update(self, next_block: XRCBlock):
+        # Add the next block to the internal blockchain
+        self.blockchain[next_block.block_index] = next_block.to_json()
+
+        # Calculate the next target in bits
+        bits = self.get_target(next_block.block_index + 1)
+
+        # Update the internal configuration based on the new block
+        self.config = NetworkConfig(
+            block_time=next_block.block_time,
+            block_index=next_block.block_index,
+            bits=bits,
+        )
+
+
+class PowSimulator(object):
+    def __init__(
+        self, network: Type[MockNetworkBase], miners: List[Type[MockMinerBase]]
+    ):
+        self.network = network
+        self.miners = miners
+
+    @property
+    def hash_rate(self):
+        return np.sum([miner.hash_rate for miner in self.miners], axis=0)
+
+    @staticmethod
+    def get_block_time(target, hashrate):
+        """
+        Note: In a proof-of-work network, block times depend on the difficulty and the hash-rate. Assuming a constant
+        hash-rate between blocks, implies the block-time can be simulated by sampling from a gamma-random variable.
+
+        We calculate the expected time-to-block as follows: We know MAX_TARGET = (2**236 - 1), and there are 2**256
+        possible hashes. Hashes which are less than the target are acceptable. The expected pay-off per-hash is
+        essentially P = target/2**256 ~ target/(MAX_TARGET*2**20) = 1/(2**20*D). Expected pay-off per-second is
+        P * H = H/(2**20 * D), which implies seconds-until-payoff equals 2**20 * D / H
+        """
+        lmbda = 2**20 * (MAX_TARGET * 1.0 / target) * 1.0 / hashrate
+
+        block_time = np.random.gamma(1, scale=lmbda)
+
+        return block_time
+
+    def run(self, nmb_iterations, seed=None):
+        for idx in range(nmb_iterations):
+            # Select a miner to create the next block, based on hash-rates
+            hr_list = np.array([miner.hash_rate for miner in self.miners])
+            weights = hr_list * 1.0 / self.hash_rate
+
+            miner_idx = np.random.choice(np.arange(len(hr_list)), 1, p=weights)[0]
+
+            time_delta = self.get_block_time(self.network.target, self.hash_rate)
+
+            next_block = self.miners[miner_idx].create_block(
+                self.network.config, time_delta, miner_idx
+            )
+
+            self.network.update(next_block)
+
+            for miner in self.miners:
+                miner.update(self.network.config, next_block)

--- a/xrc_simulations/utils.py
+++ b/xrc_simulations/utils.py
@@ -1,0 +1,14 @@
+from typing import List, Dict
+
+
+def convert_list_to_blockchain(raw_data: List[Dict]):
+    """
+    Return blockchain data in a dictionary, with the blockIndex as the key
+    """
+    blockchain = {}
+
+    for data in raw_data:
+        idx = data["blockIndex"]
+        blockchain[idx] = data
+
+    return blockchain

--- a/xrc_utils/__init__.py
+++ b/xrc_utils/__init__.py
@@ -14,4 +14,5 @@ X13_DIR = ROOT_DIR.joinpath("x13-hash")
 X11_DIR = ROOT_DIR.joinpath("x11-hash")
 
 OUTPUT_DIR = ROOT_DIR.joinpath("output")
+
 os.makedirs(OUTPUT_DIR, exist_ok=True)

--- a/xrc_utils/blockcore.py
+++ b/xrc_utils/blockcore.py
@@ -7,9 +7,9 @@ from xrc_utils.digishield import MAX_TARGET
 
 def target_to_difficulty(target: int) -> float:
     """
-    Difficulty in the Blockcore API is calculated as
+    Target and difficulty are related as
     """
-    return MAX_TARGET * 1.0 / (4096 * target)
+    return MAX_TARGET * 1.0 / target
 
 
 def get_blockcore_df(nmb_blocks=1000, offset=160000) -> pd.DataFrame:
@@ -82,5 +82,11 @@ def get_blockcore_data(nmb_blocks=1000, offset=160000) -> List[Dict]:
         assert (
             data[idx]["blockIndex"] == data[idx - 1]["blockIndex"] + 1
         ), "Indexes out of order"
+
+    # Correct an error in difficulty in Blockcore data. Blockcore is storing difficulty as MAX_TARGET_BITCOIN/target
+    # rather than MAX_TARGET_XRC/target. MAX_TARGET_XRC = 2**236 - 1, and MAX_TARGET_BITCOIN = 2**224 - 1, so the
+    # difficulty is too small by a factor of 2**12.
+    for idx in range(len(data)):
+        data[idx]["difficulty"] = 2**12 * data[idx]["difficulty"]
 
     return data

--- a/xrc_utils/digishield.py
+++ b/xrc_utils/digishield.py
@@ -1,10 +1,10 @@
-from xrc_utils import DATA_DIR
 from xrc_utils.headers import (
     serialize_header,
     bfh,
     hash_encode,
     HEADER_SIZE,
-    deserialize_header, BLOCKCHAIN_HEADERS_PATH,
+    deserialize_header,
+    BLOCKCHAIN_HEADERS_PATH,
 )
 from xrc_utils.x11 import get_pow_hash_x11
 
@@ -16,6 +16,7 @@ existing blockchain_headers file.
 """
 
 TESTNET = False
+# Note that MAX_TARGET = 2**236 - 1
 MAX_TARGET = 0x00000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
 MAX_TARGET_2 = 0x00000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
 TARGET_2_FROMBLOCK_HEIGHT = 0
@@ -79,7 +80,7 @@ def get_target(index: int, height: int) -> int:
     bits = last.get("bits")
     target = bits_to_target(bits)
 
-    nActualTimespan = last.get("timestamp") - first.get("timestamp")
+    nActualTimespan = last.get("blockTime") - first.get("blockTime")
     nTargetTimespan = 14 * 24 * 60 * 60
     nActualTimespan = max(nActualTimespan, nTargetTimespan // 4)
     nActualTimespan = min(nActualTimespan, nTargetTimespan * 4)


### PR DESCRIPTION
- Add simulation framework for testing difficulty adjustments.
- Usage is illustrated in `xrc_experiments/experiment_1.py`
    - To create an experiment inherit from the `MockNetworkBase` class, and implement the `get_target` logic
    - Can test the network by adding various hash strategies. In particular, inherit from `MockMinerBase` and implement the `set_hash_rate` logic
    - Unit tests contain a `FixtureSimulator` class, which can be used to test the algorithm against known block-times. This way we can compare difficulty adjustments against expected difficulty adjustments from real data.
    - In pure simulations, the block-time is modeled as a Gamma-random variable which depends on the network-wide hash-rate, and the current difficulty target.
 - Updates of various unit tests and notations.